### PR TITLE
PR에 대한 참고용 예시 코드

### DIFF
--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -12,15 +12,12 @@ struct JuiceMaker {
     private let fruitRepository = FruitRepository.shared
     private let diposeBag = DisposeBag()
     
-    func fruitStockObservable(of fruit: Fruit) -> Observable<Int> {
-        return self.fruitRepository.readStock(of: fruit)
+    func fetchFruitStock() -> Observable<[Fruit: Int]> {
+        return self.fruitRepository.readStock()
     }
     
-    func makeJuice(_ juice: Juice) -> Observable<Bool> {
+    func juiceMakingResult(_ juice: Juice) -> Observable<Bool> {
         let juiceObservable = self.haveFruitStock(to: juice)
-            .map{ haveEnoughFruits in
-                haveEnoughFruits.contains(false) ? false : true
-            }
             .do(onNext: { canMakeJuice in
                 guard canMakeJuice else {
                     return
@@ -31,17 +28,16 @@ struct JuiceMaker {
         return juiceObservable
     }
     
-    private func haveFruitStock(to juice: Juice) -> Observable<[Bool]> {
-        var canMake = [Bool]()
-        
-        juice.recipe.forEach { (fruit, count) in
-            self.fruitRepository.readStock(of: fruit)
-                .map{ $0 >= count }
-                .subscribe(onNext: { canMake.append($0) })
-                .disposed(by: self.diposeBag)
-        }
-        
-        return Observable.just(canMake)
+    private func haveFruitStock(to juice: Juice) -> Observable<Bool> {
+        // 이렇게 하면 구독 없이 stream을 이을 수 있다.
+        return self.fruitRepository.readStock()
+            .map { stocks in
+                let result = juice.recipe.map { fruit, count in
+                    stocks[fruit, default: 0] >= count
+                }
+                .contains(false) ? false : true
+                return result
+            }
     }
     
     private func takeFruitStock(for juice: Juice) {

--- a/JuiceMaker/JuiceMaker/Repository/FruitRepository.swift
+++ b/JuiceMaker/JuiceMaker/Repository/FruitRepository.swift
@@ -10,7 +10,7 @@ import RxSwift
 
 class FruitRepository {
     static let shared = FruitRepository()
-    private var fruitStock: Observable<[Fruit : Int]>
+    private var fruitStock: [Fruit : Int]
     static let initialStock = 10
     static let maximumStock = 100
     
@@ -19,35 +19,21 @@ class FruitRepository {
         Fruit.allCases.forEach { fruit in
             initialFruitStocks.updateValue(FruitRepository.initialStock, forKey: fruit)
         }
-        self.fruitStock = Observable.just(initialFruitStocks)
+        self.fruitStock = initialFruitStocks
     }
     
-    func readStock(of fruit: Fruit) -> Observable<Int> {
-        return self.fruitStock
-            .flatMap{ stocks in
-                Observable.just(stocks[fruit])
-                    .compactMap{ $0 }
-            }
+    func readStock() -> Observable<[Fruit : Int]> {
+        return Observable.of(self.fruitStock)
     }
     
     func updateStock(of fruit: Fruit, to newQuantity: Int) {
-        let newStocks = self.fruitStock.map{ stocks -> [Fruit : Int] in
-            var newStocks = stocks
-            newStocks.updateValue(newQuantity, forKey: fruit)
-            return newStocks
-        }
-        self.fruitStock = newStocks
+        self.fruitStock.updateValue(newQuantity, forKey: fruit)
     }
     
     func decreaseStock(of fruit: Fruit, count: Int) {
-        let newStocks = self.fruitStock.map{ stocks -> [Fruit : Int] in
-            guard let currentStock = stocks[fruit], currentStock > .zero else {
-                return [Fruit: Int]()
-            }
-            var newStocks = stocks
-            newStocks.updateValue(currentStock - count, forKey: fruit)
-            return newStocks
+        guard let currentStock = self.fruitStock[fruit], currentStock > .zero else {
+            return
         }
-        self.fruitStock = newStocks
+        self.fruitStock.updateValue(currentStock - count, forKey: fruit)
     }
 }

--- a/JuiceMaker/JuiceMaker/ViewController/EditViewController.swift
+++ b/JuiceMaker/JuiceMaker/ViewController/EditViewController.swift
@@ -25,7 +25,6 @@ class EditViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.configure()
         self.binding()
     }
     
@@ -33,15 +32,13 @@ class EditViewController: UIViewController {
         let editViewModel = EditViewModel()
         let input = EditViewModel.Input(
             viewWillAppear: self.rx.methodInvoked(#selector(UIViewController.viewWillAppear(_:))).map{ _ in },
-            strawberryStepperDidTap: self.strawberryStepper.rx.value.asObservable(),
-            bananaStepperDidTap: self.bananaStepper.rx.value.asObservable(),
-            pineappleStepperDidTap: self.pineappleStepper.rx.value.asObservable(),
-            kiwiStepperDidTap: self.kiwiStepper.rx.value.asObservable(),
-            mangoStepperDidTap: self.mangoStepper.rx.value.asObservable()
+            strawberryStepperValueChanged: self.strawberryStepper.rx.value.asObservable(),
+            bananaStepperValueChanged: self.bananaStepper.rx.value.asObservable(),
+            pineappleStepperValueChanged: self.pineappleStepper.rx.value.asObservable(),
+            kiwiStepperValueChanged: self.kiwiStepper.rx.value.asObservable(),
+            mangoStepperValueChanged: self.mangoStepper.rx.value.asObservable()
         )
         let output = editViewModel.transform(input: input)
-        
-        self.presetStepperValue(output.currentStock)
 
         output.strawberryStock
             .bind(onNext: { stock in
@@ -56,60 +53,51 @@ class EditViewController: UIViewController {
                 self.bananaStepper.value = Double(stock)
             })
             .disposed(by: self.disposeBag)
-        
+
         output.pineappleStock
             .bind(onNext: { stock in
                 self.pineappleStockLabel.text = String(stock)
                 self.pineappleStepper.value = Double(stock)
             })
             .disposed(by: self.disposeBag)
-        
+
         output.kiwiStock
             .bind(onNext: { stock in
                 self.kiwiStockLabel.text = String(stock)
                 self.kiwiStepper.value = Double(stock)
             })
             .disposed(by: self.disposeBag)
-        
+
         output.mangoStock
             .bind(onNext: { stock in
                 self.mangoStockLabel.text = String(stock)
                 self.mangoStepper.value = Double(stock)
             })
             .disposed(by: self.disposeBag)
-        
+
+        output.minimumStepperValue
+            .bind(to: self.strawberryStepper.rx.minimumValue,
+                  self.bananaStepper.rx.minimumValue,
+                  self.pineappleStepper.rx.minimumValue,
+                  self.kiwiStepper.rx.minimumValue,
+                  self.mangoStepper.rx.minimumValue)
+            .disposed(by: self.disposeBag)
+
+        output.maximumStepperValue
+            .bind(to: self.strawberryStepper.rx.maximumValue,
+                  self.bananaStepper.rx.maximumValue,
+                  self.pineappleStepper.rx.maximumValue,
+                  self.kiwiStepper.rx.maximumValue,
+                  self.mangoStepper.rx.maximumValue)
+            .disposed(by: self.disposeBag)
+
         output.alertMessage
             .subscribe(onNext: { message in
-                guard let message = message else {
-                    return
-                }
                 self.showAlert(title: "알림", message: message)
             })
             .disposed(by: self.disposeBag)
     }
-    
-    private func configure() {
-        self.strawberryStepper.minimumValue = .zero
-        self.bananaStepper.minimumValue = .zero
-        self.pineappleStepper.minimumValue = .zero
-        self.kiwiStepper.minimumValue = .zero
-        self.mangoStepper.minimumValue = .zero
-        
-        self.strawberryStepper.maximumValue = Double(FruitRepository.maximumStock)
-        self.bananaStepper.maximumValue = Double(FruitRepository.maximumStock)
-        self.pineappleStepper.maximumValue = Double(FruitRepository.maximumStock)
-        self.kiwiStepper.maximumValue = Double(FruitRepository.maximumStock)
-        self.mangoStepper.maximumValue = Double(FruitRepository.maximumStock)
-    }
-    
-    private func presetStepperValue(_ stocks: [Fruit: Double]) {
-        self.strawberryStepper.value = stocks[.strawberry] ?? .zero
-        self.bananaStepper.value = stocks[.banana] ?? .zero
-        self.pineappleStepper.value = stocks[.pineapple] ?? .zero
-        self.kiwiStepper.value = stocks[.kiwi] ?? .zero
-        self.mangoStepper.value = stocks[.mango] ?? .zero
-    }
-    
+
     private func showAlert(title: String, message: String) {
         let alertController = UIAlertController(
             title: title,

--- a/JuiceMaker/JuiceMaker/ViewController/OrderViewController.swift
+++ b/JuiceMaker/JuiceMaker/ViewController/OrderViewController.swift
@@ -64,12 +64,8 @@ class OrderViewController: UIViewController {
         output.mangoStock
             .bind(to: self.mangoStockLabel.rx.text)
             .disposed(by: self.disposeBag)
-
-        output.orderButtonBind
-            .subscribe()
-            .disposed(by: self.disposeBag)
         
-        output.resultMessage
+        output.alertMessage
             .bind(onNext: { message in
                 self.showAlert(title: "주문 결과", message: message)
             })

--- a/JuiceMaker/JuiceMaker/ViewModel/EditViewModel.swift
+++ b/JuiceMaker/JuiceMaker/ViewModel/EditViewModel.swift
@@ -34,7 +34,7 @@ class EditViewModel {
     }
     
     func transform(input: Input) -> Output {
-        let fetchStock = input.viewWillAppear
+        let fetchInitialStock = input.viewWillAppear
             .flatMap { self.juiceMaker.fetchFruitStock() }
             .share()
 
@@ -79,23 +79,23 @@ class EditViewModel {
             .share()
 
         let strawberryStock = Observable.merge(
-            fetchStock.compactMap { $0[.strawberry] },
+            fetchInitialStock.compactMap { $0[.strawberry] },
             modifiedstrawberryStock
         )
         let bananaStock = Observable.merge(
-            fetchStock.compactMap { $0[.banana] },
+            fetchInitialStock.compactMap { $0[.banana] },
             modifiedBananaStock
         )
         let pineappleStock = Observable.merge(
-            fetchStock.compactMap { $0[.pineapple] },
+            fetchInitialStock.compactMap { $0[.pineapple] },
             modifiedPineappleStock
         )
         let kiwiStock = Observable.merge(
-            fetchStock.compactMap { $0[.kiwi] },
+            fetchInitialStock.compactMap { $0[.kiwi] },
             modifiedKiwiStock
         )
         let mangoStock = Observable.merge(
-            fetchStock.compactMap { $0[.mango] },
+            fetchInitialStock.compactMap { $0[.mango] },
             modifiedMangoStock
         )
 

--- a/JuiceMaker/JuiceMaker/ViewModel/OrderResult.swift
+++ b/JuiceMaker/JuiceMaker/ViewModel/OrderResult.swift
@@ -16,6 +16,15 @@ enum OrderResult {
             return "주문 실패! 재고가 부족해요💦"
         }
     }
+
+    init(orderResult: Bool) {
+        switch orderResult {
+        case true:
+            self = .orderSuccess
+        case false:
+            self = .orderFailure
+        }
+    }
     
     case orderSuccess
     case orderFailure

--- a/JuiceMaker/JuiceMaker/ViewModel/OrderViewModel.swift
+++ b/JuiceMaker/JuiceMaker/ViewModel/OrderViewModel.swift
@@ -24,137 +24,100 @@ class OrderViewModel {
     }
     
     struct Output {
-        let strawberryStock: PublishSubject<String>
-        let bananaStock: PublishSubject<String>
-        let pineappleStock: PublishSubject<String>
-        let kiwiStock: PublishSubject<String>
-        let mangoStock: PublishSubject<String>
-        let orderButtonBind: Observable<Void>
-        let resultMessage: PublishSubject<String>
+        let strawberryStock: Observable<String>
+        let bananaStock: Observable<String>
+        let pineappleStock: Observable<String>
+        let kiwiStock: Observable<String>
+        let mangoStock: Observable<String>
+        let alertMessage: Observable<String>
     }
     
     func transform(input: Input) -> Output {
-        let resultMessage = PublishSubject<String>()
-        let strawberryStock = PublishSubject<String>()
-        let bananaStock = PublishSubject<String>()
-        let pineappleStock = PublishSubject<String>()
-        let kiwiStock = PublishSubject<String>()
-        let mangoStock = PublishSubject<String>()
+        let strawBananaJuiceOrderResult = input.strawBananaJuiceButtonDidTap
+            .flatMap { self.juiceMaker.juiceMakingResult(.strawberryBananaJuice) }
+            .share()
         
-        let strawBananaJuiceTap = input.strawBananaJuiceButtonDidTap
-            .flatMap{ self.juiceMaker.makeJuice(.strawberryBananaJuice) }
-            .do(onNext: { canMakeJuice in
-                if canMakeJuice {
-                    resultMessage.onNext(OrderResult.orderSuccess.message)
-                } else {
-                    resultMessage.onNext(OrderResult.orderFailure.message)
-                }
-            })
-            .map{ _ in }
+        let mangoKiwiJuiceOrderResult = input.mangoKiwiJuiceButtonDidTap
+            .flatMap { self.juiceMaker.juiceMakingResult(.mangoKiwiJuice) }
+            .share()
         
-        let mangoKiwiJuiceTap = input.mangoKiwiJuiceButtonDidTap
-            .flatMap{ self.juiceMaker.makeJuice(.mangoKiwiJuice) }
-            .do(onNext: { canMakeJuice in
-                if canMakeJuice {
-                    resultMessage.onNext(OrderResult.orderSuccess.message)
-                } else {
-                    resultMessage.onNext(OrderResult.orderFailure.message)
-                }
-            })
-                .map{ _ in }
+        let strawberryJuiceOrderResult = input.strawberryJuiceButtonDidTap
+            .flatMap { self.juiceMaker.juiceMakingResult(.strawberryJuice) }
+            .share()
         
-        let strawberryJuiceTap = input.strawberryJuiceButtonDidTap
-            .flatMap{ self.juiceMaker.makeJuice(.strawberryJuice) }
-            .do(onNext: { canMakeJuice in
-                if canMakeJuice {
-                    resultMessage.onNext(OrderResult.orderSuccess.message)
-                } else {
-                    resultMessage.onNext(OrderResult.orderFailure.message)
-                }
-            })
-                .map{ _ in }
+        let bananaJuiceOrderResult = input.bananaJuiceButtonDidTap
+            .flatMap { self.juiceMaker.juiceMakingResult(.bananaJuice) }
+            .share()
         
-        let bananaJuiceTap = input.bananaJuiceButtonDidTap
-            .flatMap{ self.juiceMaker.makeJuice(.bananaJuice) }
-            .do(onNext: { canMakeJuice in
-                if canMakeJuice {
-                    resultMessage.onNext(OrderResult.orderSuccess.message)
-                } else {
-                    resultMessage.onNext(OrderResult.orderFailure.message)
-                }
-            })
-                .map{ _ in }
+        let pineappleJuiceOrderResult = input.pineappleJuiceButtonDidTap
+            .flatMap { self.juiceMaker.juiceMakingResult(.pineappleJuice) }
+            .share()
         
-        let pineappleJuiceTap = input.pineappleJuiceButtonDidTap
-            .flatMap{ self.juiceMaker.makeJuice(.pineappleJuice) }
-            .do(onNext: { canMakeJuice in
-                if canMakeJuice {
-                    resultMessage.onNext(OrderResult.orderSuccess.message)
-                } else {
-                    resultMessage.onNext(OrderResult.orderFailure.message)
-                }
-            })
-                .map{ _ in }
-        
-        let kiwiJuiceTap = input.kiwiJuiceButtonDidTap
-            .flatMap{ self.juiceMaker.makeJuice(.kiwiJuice) }
-            .do(onNext: { canMakeJuice in
-                if canMakeJuice {
-                    resultMessage.onNext(OrderResult.orderSuccess.message)
-                } else {
-                    resultMessage.onNext(OrderResult.orderFailure.message)
-                }
-            })
-                .map{ _ in }
-        
-        let mangoJuiceTap = input.mangoJuiceButtonDidTap
-            .flatMap{ self.juiceMaker.makeJuice(.mangoJuice) }
-            .do(onNext: { canMakeJuice in
-                if canMakeJuice {
-                    resultMessage.onNext(OrderResult.orderSuccess.message)
-                } else {
-                    resultMessage.onNext(OrderResult.orderFailure.message)
-                }
-            })
-                .map{ _ in }
-        
-        let orderButtonBind = Observable.merge(input.viewWillAppear,
-                                               strawBananaJuiceTap,
-                                               mangoKiwiJuiceTap,
-                                               strawberryJuiceTap,
-                                               bananaJuiceTap,
-                                               pineappleJuiceTap,
-                                               kiwiJuiceTap,
-                                               mangoJuiceTap)
-            .do(onNext: {
-                self.juiceMaker.fruitStockObservable(of: .strawberry)
-                    .bind{ stock in
-                        strawberryStock.onNext(String(stock))
-                    }.dispose()
-                self.juiceMaker.fruitStockObservable(of: .banana)
-                    .bind{ stock in
-                        bananaStock.onNext(String(stock))
-                    }.dispose()
-                self.juiceMaker.fruitStockObservable(of: .pineapple)
-                    .bind{ stock in
-                        pineappleStock.onNext(String(stock))
-                    }.dispose()
-                self.juiceMaker.fruitStockObservable(of: .kiwi)
-                    .bind{ stock in
-                        kiwiStock.onNext(String(stock))
-                    }.dispose()
-                self.juiceMaker.fruitStockObservable(of: .mango)
-                    .bind{ stock in
-                        mangoStock.onNext(String(stock))
-                    }.dispose()
-            })
-                
-                return Output(strawberryStock: strawberryStock,
-                              bananaStock: bananaStock,
-                              pineappleStock: pineappleStock,
-                              kiwiStock: kiwiStock,
-                              mangoStock: mangoStock,
-                              orderButtonBind: orderButtonBind,
-                              resultMessage: resultMessage)
-                }
+        let kiwiJuiceOrderResult = input.kiwiJuiceButtonDidTap
+            .flatMap { self.juiceMaker.juiceMakingResult(.kiwiJuice) }
+            .share()
+
+        let mangoJuiceOrderResult = input.mangoJuiceButtonDidTap
+            .flatMap { self.juiceMaker.juiceMakingResult(.mangoJuice) }
+            .share()
+
+        let alertMessage = Observable.merge(
+            strawBananaJuiceOrderResult,
+            mangoKiwiJuiceOrderResult,
+            strawberryJuiceOrderResult,
+            bananaJuiceOrderResult,
+            pineappleJuiceOrderResult,
+            kiwiJuiceOrderResult,
+            mangoJuiceOrderResult
+        )
+            .map { OrderResult.init(orderResult:$0).message }
+
+        let fetchStock = Observable.merge(
+            input.viewWillAppear,
+            strawberryJuiceOrderResult.mapToVoid(),
+            strawBananaJuiceOrderResult.mapToVoid(),
+            bananaJuiceOrderResult.mapToVoid(),
+            pineappleJuiceOrderResult.mapToVoid(),
+            kiwiJuiceOrderResult.mapToVoid(),
+            mangoKiwiJuiceOrderResult.mapToVoid(),
+            mangoJuiceOrderResult.mapToVoid()
+        )
+            .flatMap { self.juiceMaker.fetchFruitStock() }
+            .share()
+
+        let strawberryStock = fetchStock
+            .compactMap { $0[.strawberry] }
+            .map(String.init)
+
+
+        let bananaStock = fetchStock
+            .compactMap { $0[.banana] }
+            .map(String.init)
+
+        let pineappleStock = fetchStock
+            .compactMap { $0[.pineapple] }
+            .map(String.init)
+
+        let kiwiStock = fetchStock
+            .compactMap { $0[.kiwi] }
+            .map(String.init)
+
+        let mangoStock = fetchStock
+            .compactMap { $0[.mango] }
+            .map(String.init)
+
+        return Output(strawberryStock: strawberryStock,
+                      bananaStock: bananaStock,
+                      pineappleStock: pineappleStock,
+                      kiwiStock: kiwiStock,
+                      mangoStock: mangoStock,
+                      alertMessage: alertMessage)
+    }
+}
+
+extension ObservableType {
+
+    func mapToVoid() -> Observable<Void> {
+        return map { _ in }
+    }
 }


### PR DESCRIPTION
Rx의 특성 상, 
1. 하나의 stream이 여러 객체 / 파일에 영향을 미치고 있으며 
2. 구조에 대한 정형화된 약속이 없으면 작은 문제라도 개선방향에 대한 설명이 쉽지 않은 점

때문에 리뷰 시 파일의 각 부분에 대한 코멘트로는 부족하다는 생각이 있었어요.

또한, 제가 PR 코멘트에서 반복해서 말하는 "operator를 잘 사용하면 구독과 Subject 없이 transform 가능하다" 에 대한 예시를 보여드리고 싶기도 했어요.

그래서 제가 호랭이의 코드를 기반으로 조금 다른 방식으로 구현해 보았는데요.
호랭이가 읽어보고 납득되는 부분이 있다면 받아들여서 반영해 보시라고 참고 혹은 예시 정도로 작성해 보았습니다.

본 pr은 깃헙의 "files Changed" 기능을 통해 비교하기 쉽도록 작성한 것이니 읽어보시고 마음대로 close 하셔도 됩니다!!😄

---
### 주요 변경사항
1. Repository
- 제가 Subject로 해보자고 해 놓고는, 다시 [Fruit : Int] 변수로 바꾸어버렸어요..
이유는 [PR 코멘트](https://github.com/horeng2/RxSwift_JuiceMaker/pull/1#discussion_r891660633)에 써 놓았습니다..하하
변수로 바꾸면서 Repository 메서드도 자연스럽게 조금씩 바뀌었습니다.
- read 메서드를 Dictionary 전체를 한번에 반환하도록 변경했습니다. 이유는 [PR코멘트2](https://github.com/horeng2/RxSwift_JuiceMaker/pull/1#issuecomment-1149063994) 의 b 때문이에요!

2. JuiceMaker
- haveFruitStock에서 subscribe하지 않아도 되도록 로직 변경

3. OrderView
- Output을 Observable로 변경 및 transform 함수의 로직 변경
- 반복되는 `map { _ in }` -> mapToVoid 함수 구현

4. EditView
- preset메서드 대신, viewWillAppear 스트림을 통해 재고정보가 stepper에 반영되도록 구현
- maximum / minimum stepperValue 또한 뷰모델이 관리할 데이터이므로, 뷰모델에서 생성하고 뷰컨에서는 bind만. (->configure함수를 대체)
- Output을 Observable로 변경 및 transform 함수의 로직 변경


3, 4 에서는 
`하나의 스트림인데 alertMessage에도 쓰이고, fruitLabel / stepperValue에도 쓰이는 상황에서 스트림을 어떻게 나눌 수 있을까?`
를 중점적으로 살펴보시면 좋을 것 같아요 :)

더불어, share를 썼을때와 안썼을 때의 동작의 차이도 살펴보세요!


---

변경부분들을 확인하시고 의문점이나 논의할 부분이 있다면 review 기능으로 코멘트 주셔도 좋아요!
@horeng2 